### PR TITLE
fix: correctly accept JIMP instances

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,9 @@ export default function mergeImg(images, {
   }
 
   const processImg = (img) => {
+    if(img instanceof Jimp) {
+      return {img};
+    }
     if (isPlainObj(img)) {
       const {src, offsetX, offsetY} = img;
 


### PR DESCRIPTION
Passing JIMP instances in the first argument doesn't work as docs suggest.

#10 